### PR TITLE
Add '-' to fix password validation on signup

### DIFF
--- a/client/app/utils/validation.js
+++ b/client/app/utils/validation.js
@@ -1,5 +1,5 @@
 const emailPattern = /^[-a-z0-9~!$%^&*_=+}{\'?]+(\.[-a-z0-9~!$%^&*_=+}{\'?]+)*@([a-z0-9_][-a-z0-9_]*(\.[-a-z0-9_]+)*\.(io|xyz|fr|cn|ca|us|dz||aero|arpa|biz|com|coop|edu|gov|info|int|mil|museum|name|net|org|pro|travel|mobi|[a-z][a-z])|([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}))(:[0-9]{1,5})?$/i
-const passwordPattern = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[$@$!%*#?&])[A-Za-z\d$@$!%*#?&]{8,}$/
+const passwordPattern = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[$@$!%*#?&-])[A-Za-z\d$@$!%*#?&-]{8,}$/
 const urlPattern = /^((http[s]?|ftp):\/)?\/?([^:\/\s]+)((\/\w+)*\/)([\w\-\.]+[^#?\s]+)(.*)?(#[\w\-]+)?$/
 
 exports.validateRegister = (data) => {


### PR DESCRIPTION
Safari automatically generates password suggestions which include dashes.  The app's validations were rejecting these passwords on signup even though they match all other criteria.  Adding the '-' fixes this.  Fixes issue #15.